### PR TITLE
Fix sqlite3.obj Path While Building on Windows

### DIFF
--- a/build-cl.bat
+++ b/build-cl.bat
@@ -1,4 +1,4 @@
 @echo off
 cl /nologo /c amalgamation/sqlite3.c -Fo:bindings/bin/sqlite3.obj
-lib /nologo bin/sqlite3.obj /out:"bindings/bin/sqlite3.lib"
+lib /nologo bindings/bin/sqlite3.obj /out:"bindings/bin/sqlite3.lib"
 echo bindings/sqlite3.lib compiled!


### PR DESCRIPTION
Wouldn't compile otherwise (note that it still created the success message afterwards since there's no error checking).