### PR TITLE
`sqlite3_threadsafe()` Returns `int`, Not `b32`

### DIFF
--- a/bindings/sqlite3.odin
+++ b/bindings/sqlite3.odin
@@ -42,7 +42,7 @@ foreign sqlite3 {
     // returns `nil`.
     compileoption_get  :: proc (n: i32) -> cstring ---
     // Test to see if sqlite is compiled with threadsafe options.
-    threadsafe         :: proc () -> b32 ---
+    threadsafe         :: proc () -> i32 ---
 }
 
 // Database connection handle.


### PR DESCRIPTION
Signature: [`int sqlite3_threadsafe(void)`](https://www.sqlite.org/c3ref/threadsafe.html)

[The return value of the sqlite3_threadsafe() interface is the value of SQLITE_THREADSAFE set at compile-time.](https://www.sqlite.org/threadsafe.html)

[SQLITE_THREADSAFE=<0 or 1 or 2>](https://www.sqlite.org/compile.html#threadsafe)